### PR TITLE
Add code block syntax highlight for card answer field

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem 'devise', '~> 4.8', '>= 4.8.1'
 gem 'activeadmin', '~> 2.13', '>= 2.13.1'
 gem 'i18n', '~> 1.10'
+gem 'rouge', '~> 3.28'
 gem 'redcarpet', '~> 3.5', '>= 3.5.1'
 gem 'omniauth-google-oauth2', '~> 1.0', '>= 1.0.1'
 gem 'omniauth-github', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
+    rouge (3.28.0)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
     rspec-expectations (3.11.0)
@@ -363,6 +364,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.5)
   redcarpet (~> 3.5, >= 3.5.1)
+  rouge (~> 3.28)
   rspec-rails
   rubocop (~> 1.29)
   rubocop-rails (>= 2.14.2)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,4 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def md_format(text)
-    options = %i[no_intra_emphasis fenced_code_blocks autolink strikethrough
-                 hard_wrap disable_indented_code_blocks]
-    Markdown.new(text, *options).to_html
-  end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module MarkdownHelper
+  class CustomRender < Redcarpet::Render::HTML
+    include Rouge::Plugins::Redcarpet
+  end
+
+  def md_format(text)
+    render_options = {
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: { rel: 'nofollow' }
+    }
+    renderer = CustomRender.new(render_options)
+
+    extensions = {
+      autolink: true,
+      fenced_code_blocks: true,
+      lax_spacing: true,
+      no_intra_emphasis: true,
+      strikethrough: true,
+      superscript: true
+    }
+    Redcarpet::Markdown.new(renderer, extensions).render(text)
+  end
+end

--- a/app/views/cards/edit.html.erb
+++ b/app/views/cards/edit.html.erb
@@ -1,19 +1,22 @@
 <h1>Edit card</h1>
 <%= form_with model: @card do |form| %>
-  <div class="form-group w-50">
-    <%= form.label :question, class: "form-label" %><br />
-    <%= form.text_field :question, placeholder: "question", class: "form-control" %>
-  </div>
-   <div class="form-group w-50">
-  <%= form.label :answer, class: "form-label" %><br />
-  <%= form.text_field :answer, placeholder: "answer", class: "form-control" %>
-  </div>
-   <div class="form-group w-50">
-  <br />
+ <div class="row">
+  <div class="col-md-5 mb-2 ">
+    <div class="form-floating">
+      <%= form.text_field :question, placeholder: "Question", class: "form-control", id: "floatingInput"%>
+      <%= form.label :question, "Insert a question", for: "floatingInput"%>
+    </div>
+</div>
+<div class="col-md-7 mb-2">
+      <div class="form-floating">
+      <%= form.text_area :answer, placeholder: "answer", class: "form-control", id: "floatingInputAnswer", style: "height: 100px"%>
+      <%= form.label :answer, "Insert an answer", for: "floatingInputAnswer"%>
+    </div>
+    </div>
+    </div>
   <%= form.label :board_id, class: "form-label" %>
   <%= form.collection_select :board_id, Board.order(:name), :id, :name, options = {:prompt => 'Select a board...'}, html_options = { class: "form-select" } %>
    <br />
-  </div>
   <%= form.submit class: "btn btn-primary"%>
 <% end %>
 <br />

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,9 @@
     <!-- Warning !! ensure that "stylesheet_pack_tag" is used, line below -->
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <style type="text/css">
+      <%= Rouge::Themes::IgorPro.render(:scope => '.highlight') %>
+    </style>
   </head>
 
   <body>

--- a/config/initializers/rouge.rb
+++ b/config/initializers/rouge.rb
@@ -1,0 +1,1 @@
+require 'rouge/plugins/redcarpet'


### PR DESCRIPTION
https://trello.com/c/o8jPQwUJ/25-allow-code-block-syntax-highlight-for-card-answer-field
![Снимок экрана от 2022-05-30 21-03-42](https://user-images.githubusercontent.com/25932279/171043089-93333668-aa1c-46ef-b108-e4dc3c47f6b1.png)
![Снимок экрана от 2022-05-30 21-04-26](https://user-images.githubusercontent.com/25932279/171043097-6947e916-039c-4b51-9dc0-793c3cf395fb.png)

